### PR TITLE
Allow function calls at root of query

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -140,16 +140,14 @@ export const getSyntaxProxy = (config?: {
         // we should extend it. If none is available, we should create a new query.
         const structure = target.structure || {};
         const targetValue = typeof value === 'undefined' ? propertyValue : value;
-        const pathJoined = path.length > 0 ? path.join('.') : '.';
+
+        const pathParts = config?.rootProperty ? [config.rootProperty, ...path] : path;
+        const pathJoined = pathParts.length > 0 ? pathParts.join('.') : '.';
 
         if (pathJoined === '.') {
           Object.assign(structure, targetValue);
         } else {
-          setProperty(
-            structure,
-            config?.rootProperty ? `${config.rootProperty}.${pathJoined}` : pathJoined,
-            targetValue,
-          );
+          setProperty(structure, pathJoined, targetValue);
         }
 
         // If the function call is happening inside a batch, return a new proxy, to

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -144,11 +144,7 @@ export const getSyntaxProxy = (config?: {
         const pathParts = config?.rootProperty ? [config.rootProperty, ...path] : path;
         const pathJoined = pathParts.length > 0 ? pathParts.join('.') : '.';
 
-        if (pathJoined === '.') {
-          Object.assign(structure, targetValue);
-        } else {
-          setProperty(structure, pathJoined, targetValue);
-        }
+        setProperty(structure, pathJoined, targetValue);
 
         // If the function call is happening inside a batch, return a new proxy, to
         // allow for continuing to chain `get` accessors and function calls after

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -66,8 +66,13 @@ const setPropertyViaPathSegments = (
 };
 
 export const setProperty = <T extends object, K>(obj: T, path: string, value: K): T => {
-  const segments = getPathSegments(path);
-  setPropertyViaPathSegments(obj, segments, value);
+  if (path === '.') {
+    Object.assign(obj, value);
+  } else {
+    const segments = getPathSegments(path);
+    setPropertyViaPathSegments(obj, segments, value);
+  }
+
   return obj;
 };
 

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -320,4 +320,24 @@ describe('syntax proxy', () => {
       },
     ]);
   });
+
+  test('using a function call at the root', async () => {
+    const getQueryHandler = { callback: () => undefined };
+    const getQueryHandlerSpy = spyOn(getQueryHandler, 'callback');
+
+    const getProxy = getSyntaxProxy({
+      rootProperty: 'get',
+      callback: getQueryHandlerSpy,
+    });
+
+    getProxy({ account: null });
+
+    const finalQuery = {
+      get: {
+        account: null,
+      },
+    };
+
+    expect(getQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
+  });
 });


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/syntax/pull/16 and makes it possible to already open the function call at the root of a query (right after the query type).