### PR TITLE
Provide full model syntax for queries

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,4 +1,5 @@
 import type { AsyncLocalStorage } from 'node:async_hooks';
+import { model } from '@/src/schema';
 import { setProperty } from '@/src/utils';
 import { QUERY_SYMBOLS, type Query } from '@ronin/compiler';
 
@@ -145,6 +146,11 @@ export const getSyntaxProxy = (config?: {
         const pathJoined = pathParts.length > 0 ? pathParts.join('.') : '.';
 
         setProperty(structure, pathJoined, targetValue);
+
+        // If a `create.model` query was provided, serialize the model structure.
+        if (config?.rootProperty === 'create' && structure?.create?.model) {
+          structure.create.model = model(structure.create.model);
+        }
 
         // If the function call is happening inside a batch, return a new proxy, to
         // allow for continuing to chain `get` accessors and function calls after

--- a/src/schema/primitives.ts
+++ b/src/schema/primitives.ts
@@ -47,7 +47,10 @@ export type SyntaxField<Type extends ModelField['type']> = SyntaxItem<FieldOutpu
  */
 const primitive = <T extends ModelField['type']>(type: T) => {
   return (initialAttributes: FieldInput<T> = {}) => {
-    return getSyntaxProxy()({ ...initialAttributes, type }) as Chain<FieldOutput<T>>;
+    return getSyntaxProxy({ propertyValue: true })({
+      ...initialAttributes,
+      type,
+    }) as Chain<FieldOutput<T>>;
   };
 };
 

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -16,7 +16,9 @@ import type {
  * @returns The serialized fields.
  */
 export const serializeFields = (fields?: Record<string, PrimitivesItem>) => {
-  return Object.entries(fields ?? {}).flatMap(
+  if (!fields) return fields;
+
+  return Object.entries(fields).flatMap(
     ([key, initialValue]): Array<ModelField> | ModelField => {
       let value = initialValue?.structure;
 
@@ -28,7 +30,7 @@ export const serializeFields = (fields?: Record<string, PrimitivesItem>) => {
           result[`${key}.${k}`] = value[k];
         }
 
-        return serializeFields(result);
+        return serializeFields(result) || [];
       }
 
       return {

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { describe, expect, spyOn, test } from 'bun:test';
 
 import { type SyntaxItem, getBatchProxy, getSyntaxProxy } from '@/src/queries';
+import { string } from '@/src/schema';
 import { QUERY_SYMBOLS, type Query } from '@ronin/compiler';
 
 describe('syntax proxy', () => {
@@ -335,6 +336,41 @@ describe('syntax proxy', () => {
     const finalQuery = {
       get: {
         account: null,
+      },
+    };
+
+    expect(getQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
+  });
+
+  test('creating a model via query using primitive helpers', async () => {
+    const getQueryHandler = { callback: () => undefined };
+    const getQueryHandlerSpy = spyOn(getQueryHandler, 'callback');
+
+    const createProxy = getSyntaxProxy({
+      rootProperty: 'create',
+      callback: getQueryHandlerSpy,
+    });
+
+    createProxy.model({
+      slug: 'account',
+
+      fields: {
+        handle: string().required(),
+      },
+    });
+
+    const finalQuery = {
+      create: {
+        model: {
+          slug: 'account',
+          fields: [
+            {
+              type: 'string',
+              slug: 'handle',
+              required: true,
+            },
+          ],
+        },
       },
     };
 

--- a/tests/schema/model.test.ts
+++ b/tests/schema/model.test.ts
@@ -16,8 +16,6 @@ describe('models', () => {
       slug: 'account',
       // @ts-expect-error: The Account object has 'pluralSlug'.
       pluralSlug: 'accounts',
-      // @ts-expect-error: The Account object has 'fields'.
-      fields: [],
     });
   });
 
@@ -36,8 +34,6 @@ describe('models', () => {
       pluralSlug: 'accounts',
       // @ts-expect-error: The Account object has 'name'.
       name: 'Account',
-      // @ts-expect-error: The Account object has 'fields'.
-      fields: [],
     });
   });
 
@@ -59,8 +55,6 @@ describe('models', () => {
       name: 'Account',
       // @ts-expect-error: The Account object has 'pluralName'.
       pluralName: 'Accounts',
-      // @ts-expect-error: The Account object has 'fields'.
-      fields: [],
     });
   });
 

--- a/tests/utils/serializers.test.ts
+++ b/tests/utils/serializers.test.ts
@@ -23,7 +23,7 @@ describe('serializers', () => {
     ]);
 
     // Test empty fields case
-    expect(serializeFields()).toEqual([]);
+    expect(serializeFields()).toBeUndefined();
   });
 
   test('serializePresets', () => {


### PR DESCRIPTION
This change ensures that schema queries can make use of the same syntax that is used for defining the database schema in code, with exactly the same syntax helpers as well:

```typescript
import { create } from 'ronin';
import { string } from 'ronin/schema';

await create.model({
  slug: 'account',
  fields: {
    handle: string().required()
  }
});
```

In an upcoming iteration, the `ronin/schema` export will also provide other syntax utilities, such as functions like `json_patch` that SQLite provides natively.