### PR TITLE
Ensure reliable query serialization

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -174,36 +174,23 @@ export const getSyntaxProxy = (config?: {
 };
 
 /**
- * Executes a batch of operations and handles their results. It is used to
- * execute multiple queries at once and return their results at once.
+ * Obtains a list of queries from a function by wrapping the queries into a context.
  *
- * @param operations - A function that returns an array of Promises. Each
- * Promise should resolve with a Query object.
- * @param config - An object containing configuration for the composed structures.
+ * @param operations - A function that contains multiple query functions.
  *
- * @returns A Promise that resolves with a tuple of the results of the queries.
+ * @returns A list of queries and their respective options.
  *
  * ### Usage
  * ```typescript
- * const results = await getBatchProxy(() => [
+ * const queries = getBatchProxy(() => [
  *   get.accounts(),
  *   get.account.with.email('mike@gmail.com')
- * ], {
- *   // Execute the queries and return the results
- *   callback: async (queries) => {}
- * });
+ * ]);
  * ```
  */
-export const getBatchProxy = <
-  T extends
-    | [Promise<any> | any, ...Array<Promise<any> | any>]
-    | Array<Promise<any> | any>,
->(
-  operations: () => T,
-  config?: {
-    callback?: (queries: Array<SyntaxItem<Query>>) => Promise<any> | any;
-  },
-): Promise<PromiseTuple<T>> | T => {
+export const getBatchProxy = (
+  operations: () => Array<SyntaxItem<Query>>,
+): Array<SyntaxItem<Query>> => {
   let queries: Array<SyntaxItem<Query>> = [];
 
   IN_BATCH = true;
@@ -215,12 +202,7 @@ export const getBatchProxy = <
   // therefore return the respective `Proxy` instances, which wouldn't be logged as plain
   // objects, thereby making development more difficult. To avoid this, we are creating a
   // plain object containing the same properties as the `Proxy` instances.
-  const cleanQueries = queries.map((details) => ({ ...details }));
-
-  // If no handler is available, return queries directly.
-  if (!config?.callback) return cleanQueries as PromiseTuple<T> | T;
-
-  return config.callback(cleanQueries) as PromiseTuple<T> | T;
+  return queries.map((details) => ({ ...details }));
 };
 
 type NestedObject = {

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -87,14 +87,8 @@ export const serializeTriggers = (triggers?: Array<ModelTrigger<Array<ModelField
  * @returns The serialized query.
  */
 export const serializeQueries = (query: () => Array<Query>) => {
-  const queryList = getBatchProxy(
-    () => {
-      return query();
-    },
-    {},
-    (queries) => {
-      return queries.map((query) => query.structure);
-    },
-  );
+  const queryList = getBatchProxy(() => {
+    return query();
+  });
   return queryList.map(({ structure }) => structure);
 };

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -1,9 +1,10 @@
-import { getBatchProxy } from '@/src/queries';
+import { type SyntaxItem, getBatchProxy } from '@/src/queries';
 import type { PrimitivesItem } from '@/src/schema/model';
 import type {
   GetInstructions,
   ModelField,
   ModelTrigger,
+  Query,
   WithInstruction,
 } from '@ronin/compiler';
 
@@ -51,6 +52,7 @@ export const serializePresets = (
   presets?: Record<string, WithInstruction | GetInstructions>,
 ) => {
   if (!presets) return undefined;
+
   return Object.entries(presets).map(([key, value]) => {
     return {
       slug: key,
@@ -70,8 +72,12 @@ export const serializePresets = (
 export const serializeTriggers = (triggers?: Array<ModelTrigger<Array<ModelField>>>) => {
   if (!triggers) return undefined;
 
-  return triggers.map((trigger) => ({
-    ...trigger,
-    effects: getBatchProxy(trigger.effects).map(({ structure }) => structure),
-  }));
+  return triggers.map((trigger) => {
+    const effectQueries = trigger.effects as unknown as () => Array<SyntaxItem<Query>>;
+
+    return {
+      ...trigger,
+      effects: getBatchProxy(effectQueries).map(({ structure }) => structure),
+    };
+  });
 };

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -87,7 +87,7 @@ export const serializeTriggers = (triggers?: Array<ModelTrigger<Array<ModelField
  * @returns The serialized query.
  */
 export const serializeQueries = (query: () => Array<Query>) => {
-  const queryObject = getBatchProxy(
+  const queryList = getBatchProxy(
     () => {
       return query();
     },
@@ -96,5 +96,5 @@ export const serializeQueries = (query: () => Array<Query>) => {
       return queries.map((query) => query.structure);
     },
   );
-  return queryObject;
+  return queryList.map(({ structure }) => structure);
 };

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -4,7 +4,6 @@ import type {
   GetInstructions,
   ModelField,
   ModelTrigger,
-  Query,
   WithInstruction,
 } from '@ronin/compiler';
 
@@ -71,24 +70,8 @@ export const serializePresets = (
 export const serializeTriggers = (triggers?: Array<ModelTrigger<Array<ModelField>>>) => {
   if (!triggers) return undefined;
 
-  return triggers.map((trigger) => {
-    return {
-      ...trigger,
-      effects: serializeQueries(trigger.effects as unknown as () => Array<Query>),
-    };
-  });
-};
-
-/**
- * Serialize a RONIN query to query objects.
- *
- * @param queries - The query to serialize.
- *
- * @returns The serialized query.
- */
-export const serializeQueries = (query: () => Array<Query>) => {
-  const queryList = getBatchProxy(() => {
-    return query();
-  });
-  return queryList.map(({ structure }) => structure);
+  return triggers.map((trigger) => ({
+    ...trigger,
+    effects: getBatchProxy(trigger.effects).map(({ structure }) => structure),
+  }));
 };

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -127,11 +127,9 @@ describe('syntax proxy', () => {
   test('using async context', async () => {
     const get = getSyntaxProxy({ rootProperty: 'get' });
 
-    const details = getBatchProxy(() => [get.account()], {
-      callback: (queries) => (queries.length === 1 ? { result: true } : null),
-    });
+    const queries = getBatchProxy(() => [get.account()]);
 
-    expect(details).toMatchObject({
+    expect(queries.length === 1 ? { result: true } : null).toMatchObject({
       result: true,
     });
   });

--- a/tests/utils/serializers.test.ts
+++ b/tests/utils/serializers.test.ts
@@ -4,7 +4,6 @@ import { type SyntaxField, link } from '@/src/schema';
 import {
   serializeFields,
   serializePresets,
-  serializeQueries,
   serializeTriggers,
 } from '@/src/utils/serializers';
 
@@ -90,14 +89,6 @@ describe('serializers', () => {
     const triggers = serializeTriggers();
     // @ts-expect-error: Triggers can be undefined.
     expect(triggers).toStrictEqual(undefined);
-  });
-
-  test('serialize query', () => {
-    const add = getSyntaxProxy({ rootProperty: 'add' });
-
-    const query = serializeQueries(() => [add.account.to({ name: 'Lorena' })]);
-
-    expect(query).toEqual([{ add: { account: { to: { name: 'Lorena' } } } }]);
   });
 });
 


### PR DESCRIPTION
This change ensures that batches of queries are reliably serialized with the least amount of logic possible.