### PR TITLE
Avoid empty model attributes

### DIFF
--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -152,29 +152,25 @@ type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 export const model = <Fields extends RecordWithoutForbiddenKeys<Primitives>>(
   model: Model<Fields>,
 ): Expand<FieldsToTypes<Fields>> & Expand<RoninFields> => {
-  const {
-    slug,
-    pluralSlug,
-    name,
-    pluralName,
-    identifiers,
-    idPrefix,
-    fields,
-    indexes,
-    presets,
-    triggers,
-  } = model;
+  const newModel = { ...model };
 
-  return {
-    slug,
-    pluralSlug,
-    name,
-    pluralName,
-    identifiers,
-    idPrefix,
-    fields: serializeFields(fields as RecordWithoutForbiddenKeys<PrimitivesItem>),
-    presets: serializePresets(presets),
-    triggers: serializeTriggers(triggers),
-    indexes,
-  } as unknown as Expand<FieldsToTypes<Fields>> & Expand<RoninFields>;
+  if (newModel.fields) {
+    newModel.fields = serializeFields(
+      newModel.fields as RecordWithoutForbiddenKeys<PrimitivesItem>,
+    ) as unknown as typeof newModel.fields;
+  }
+
+  if (newModel.presets) {
+    newModel.presets = serializePresets(
+      newModel.presets,
+    ) as unknown as typeof newModel.presets;
+  }
+
+  if (newModel.triggers) {
+    newModel.triggers = serializeTriggers(
+      newModel.triggers,
+    ) as unknown as typeof newModel.triggers;
+  }
+
+  return newModel as unknown as Expand<FieldsToTypes<Fields>> & Expand<RoninFields>;
 };

--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -71,11 +71,6 @@ export interface Model<Fields>
   fields?: Fields;
 
   /**
-   * Predefined query instructions that can be reused across multiple different queries.
-   */
-  presets?: Record<string, GetInstructions | WithInstruction>;
-
-  /**
    * Database indexes to optimize query performance.
    */
   indexes?: Array<ModelIndex<Array<ModelField & { slug: keyof Fields }>>>;
@@ -84,6 +79,11 @@ export interface Model<Fields>
    * Queries that run automatically in response to other queries.
    */
   triggers?: Array<ModelTrigger<Array<ModelField & { slug: keyof Fields }>>>;
+
+  /**
+   * Predefined query instructions that can be reused across multiple different queries.
+   */
+  presets?: Record<string, GetInstructions | WithInstruction>;
 }
 
 // This type maps the fields of a model to their types.
@@ -160,16 +160,16 @@ export const model = <Fields extends RecordWithoutForbiddenKeys<Primitives>>(
     ) as unknown as typeof newModel.fields;
   }
 
-  if (newModel.presets) {
-    newModel.presets = serializePresets(
-      newModel.presets,
-    ) as unknown as typeof newModel.presets;
-  }
-
   if (newModel.triggers) {
     newModel.triggers = serializeTriggers(
       newModel.triggers,
     ) as unknown as typeof newModel.triggers;
+  }
+
+  if (newModel.presets) {
+    newModel.presets = serializePresets(
+      newModel.presets,
+    ) as unknown as typeof newModel.presets;
   }
 
   return newModel as unknown as Expand<FieldsToTypes<Fields>> & Expand<RoninFields>;

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -15,8 +15,8 @@ import type {
  *
  * @returns The serialized fields.
  */
-export const serializeFields = (fields?: Record<string, PrimitivesItem>) => {
-  if (!fields || Array.isArray(fields)) return fields;
+export const serializeFields = (fields: Record<string, PrimitivesItem>) => {
+  if (Array.isArray(fields)) return fields;
 
   return Object.entries(fields).flatMap(
     ([key, initialValue]): Array<ModelField> | ModelField => {
@@ -49,10 +49,8 @@ export const serializeFields = (fields?: Record<string, PrimitivesItem>) => {
  * @returns The serialized fields.
  */
 export const serializePresets = (
-  presets?: Record<string, WithInstruction | GetInstructions>,
+  presets: Record<string, WithInstruction | GetInstructions>,
 ) => {
-  if (!presets) return undefined;
-
   return Object.entries(presets).map(([key, value]) => {
     return {
       slug: key,
@@ -69,9 +67,7 @@ export const serializePresets = (
  *
  * @returns The serialized triggers array, or undefined if no triggers were provided.
  */
-export const serializeTriggers = (triggers?: Array<ModelTrigger<Array<ModelField>>>) => {
-  if (!triggers) return undefined;
-
+export const serializeTriggers = (triggers: Array<ModelTrigger<Array<ModelField>>>) => {
   return triggers.map((trigger) => {
     const effectQueries = trigger.effects as unknown as () => Array<SyntaxItem<Query>>;
 

--- a/tests/schema/model.test.ts
+++ b/tests/schema/model.test.ts
@@ -589,6 +589,41 @@ describe('models', () => {
     });
   });
 
+  test('create model with presets', () => {
+    const Account = model({
+      slug: 'account',
+      presets: {
+        onlyName: {
+          with: {
+            space: {
+              being: 'spa_m9h8oha94helaji',
+            },
+          },
+          selecting: ['name'],
+        },
+      },
+    });
+
+    expect(Account).toEqual({
+      // @ts-expect-error: The Account object has 'slug'.
+      slug: 'account',
+      // @ts-expect-error: The Account object has 'presets'.
+      presets: [
+        {
+          slug: 'onlyName',
+          instructions: {
+            with: {
+              space: {
+                being: 'spa_m9h8oha94helaji',
+              },
+            },
+            selecting: ['name'],
+          },
+        },
+      ],
+    });
+  });
+
   test('create model with nested fields', () => {
     const Account = model({
       slug: 'account',

--- a/tests/utils/serializers.test.ts
+++ b/tests/utils/serializers.test.ts
@@ -20,9 +20,6 @@ describe('serializers', () => {
         type: 'link',
       },
     ]);
-
-    // Test empty fields case
-    expect(serializeFields()).toBeUndefined();
   });
 
   test('serializePresets', () => {
@@ -83,12 +80,6 @@ describe('serializers', () => {
         fields: [{ slug: 'name' }],
       },
     ]);
-  });
-
-  test('serialize empty triggers', () => {
-    const triggers = serializeTriggers();
-    // @ts-expect-error: Triggers can be undefined.
-    expect(triggers).toStrictEqual(undefined);
   });
 });
 


### PR DESCRIPTION
This change ensures that models, after they are serialized, never contain any `undefined` attributes.