### PR TITLE
Ensure correct batch context for queries

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -83,6 +83,10 @@ export const getSyntaxProxy = (config?: {
         // all queries within it think they are running inside a batch transaction,
         // in order to retrieve their serialized values.
         if (typeof value === 'function') {
+          // Temporarily store the original value of `IN_BATCH`, so that we can resume it
+          // after the nested function has been called.
+          const ORIGINAL_IN_BATCH = IN_BATCH;
+
           // Since `value()` is synchronous, `IN_BATCH` should not affect any
           // other queries somewhere else in the app, even if those are run inside
           // an asynchronous function, so we don't need to use `IN_BATCH_ASYNC`,
@@ -117,7 +121,8 @@ export const getSyntaxProxy = (config?: {
             value = wrapExpressions(value);
           }
 
-          IN_BATCH = false;
+          // Restore the original value of `IN_BATCH`.
+          IN_BATCH = ORIGINAL_IN_BATCH;
         }
 
         // If the function call is happening after an existing function call in the

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -211,17 +211,16 @@ describe('syntax proxy', () => {
   test('using nested function as argument in batch', async () => {
     // It's important to define the `callback` here, in order to guarantee that the
     // queries are executed standalone if no batch context is detected.
-    const addProxy = getSyntaxProxy({ rootProperty: 'add', callback: () => undefined });
-    const getProxy = getSyntaxProxy({ rootProperty: 'get', callback: () => undefined });
-    const alterProxy = getSyntaxProxy({
-      rootProperty: 'alter',
-      callback: () => undefined,
-    });
+    const callback = () => undefined;
+
+    const addProxy = getSyntaxProxy({ rootProperty: 'add', callback });
+    const getProxy = getSyntaxProxy({ rootProperty: 'get', callback });
+    const alterProxy = getSyntaxProxy({ rootProperty: 'alter', callback });
 
     const queryList = getBatchProxy(() => [
       addProxy.newUsers.to(() => getProxy.oldUsers()),
       // Assert whether function chaining is still possible after a nested function call,
-      // since the former is able to manipulate the batch context.
+      // since the latter is able to manipulate the batch context.
       alterProxy
         .model('newUsers')
         .to({ slug: 'accounts' }),


### PR DESCRIPTION
This change resolves a bug reported [on Discord](https://discord.com/channels/1099977902629589095/1099977903678173206/1328097169873440871) by ensuring that queries are able to correctly detect whether they are run inside a batch transaction, or not.