### PR TITLE
Ensure simpler test assertions

### DIFF
--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -99,24 +99,12 @@ describe('syntax proxy', () => {
     const setQueryHandler = { callback: () => undefined };
     const setQueryHandlerSpy = spyOn(setQueryHandler, 'callback');
 
-    /**
-     * Determines whether the provided value is storable as a binary object, or not.
-     *
-     * @param value - The value to check.
-     *
-     * @returns A boolean indicating whether the provided value is storable, or not.
-     */
-    const isStorableObject = (value: unknown): boolean =>
-      (typeof File !== 'undefined' && value instanceof File) ||
-      (typeof ReadableStream !== 'undefined' && value instanceof ReadableStream) ||
-      (typeof Blob !== 'undefined' && value instanceof Blob) ||
-      (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) ||
-      (typeof Buffer !== 'undefined' && Buffer.isBuffer(value));
-
     const setProxy = getSyntaxProxy({
       rootProperty: 'set',
       callback: setQueryHandlerSpy,
-      replacer: isStorableObject,
+      replacer: (value: unknown) => {
+        return value instanceof File ? value : JSON.parse(JSON.stringify(value));
+      },
     });
 
     const file = new File(['test'], 'test.txt');


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/syntax/pull/27 and improves the test for asserting blob-like structures as values (such as `File`) even further, by simplifying the test.