### PR TITLE
Ensure correct test assertions

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -235,7 +235,7 @@ export function getSyntaxProxy(config?: {
           // For example, `Date` objects will be converted into ISO strings.
           value = mutateStructure(
             value,
-            options?.replacer || ((value) => JSON.parse(JSON.stringify(value))),
+            config?.replacer || ((value) => JSON.parse(JSON.stringify(value))),
           );
         }
 


### PR DESCRIPTION
I noticed that the test `using field with file` was not actually working correctly, because `toHaveBeenCalledWith` in Bun doesn't seem to correctly handle objects like `File` or `Date`.

Meaning that, in the final comparison, it considers `{}` (an empty object) and the actual object (e.g. `Date`) to be the same, which is of course not true.