### PR TITLE
Gracefully handle undefined instructions

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -54,56 +54,56 @@ let IN_BATCH = false;
 export function getSyntaxProxy(config?: {
   rootProperty?: never;
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): any;
 
 export function getSyntaxProxy(config?: {
   rootProperty?: 'get';
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): DeepCallable<GetQuery>;
 
 export function getSyntaxProxy(config?: {
   rootProperty?: 'set';
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): DeepCallable<SetQuery>;
 
 export function getSyntaxProxy(config?: {
   rootProperty?: 'add';
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): DeepCallable<AddQuery>;
 
 export function getSyntaxProxy(config?: {
   rootProperty?: 'remove';
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): DeepCallable<RemoveQuery>;
 
 export function getSyntaxProxy(config?: {
   rootProperty?: 'count';
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): DeepCallable<CountQuery, number>;
 
 export function getSyntaxProxy(config?: {
   rootProperty?: 'create';
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): DeepCallable<CreateQuery, Model>;
 
 export function getSyntaxProxy(config?: {
   rootProperty?: 'alter';
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): DeepCallable<
   AlterQuery,
@@ -113,7 +113,7 @@ export function getSyntaxProxy(config?: {
 export function getSyntaxProxy(config?: {
   rootProperty?: 'drop';
   callback?: (query: Query, options?: Record<string, unknown>) => Promise<any> | any;
-  replacer?: Parameters<typeof mutateStructure>[1];
+  replacer?: (value: unknown) => { value: unknown; serialize: boolean };
   propertyValue?: unknown;
 }): DeepCallable<DropQuery, Model>;
 

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -132,6 +132,29 @@ describe('syntax proxy', () => {
     expect(setQuery).toMatchObject(finalQuery);
   });
 
+  test('using `undefined` instruction`', () => {
+    let getQuery: Query | undefined;
+
+    const getProxy = getSyntaxProxy({
+      rootProperty: 'get',
+      callback: (value) => {
+        getQuery = value;
+      },
+    });
+
+    getProxy.accounts({
+      after: undefined,
+    });
+
+    const finalQuery = {
+      get: {
+        accounts: {},
+      },
+    };
+
+    expect(getQuery).toMatchObject(finalQuery);
+  });
+
   // Since `name` is a native property of functions and queries contain function calls,
   // we have to explicitly assert whether it can be used as a field slug.
   test('using field with slug `name`', () => {


### PR DESCRIPTION
This change ensures that query instructions containing `undefined` as their value do not cause a crash and are instead automatically ignored in the final JSON serialization.