### PR TITLE
Updated `blob` field return type

### DIFF
--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -15,10 +15,11 @@ import {
 } from '@/src/utils/serializers';
 import type {
   GetInstructions,
+  Model as RawModel,
   ModelField,
   ModelIndex,
   ModelTrigger,
-  Model as RawModel,
+  StoredObject,
   WithInstruction,
 } from '@ronin/compiler';
 
@@ -102,7 +103,7 @@ type FieldsToTypes<F> = F extends Record<string, Primitives>
                 : F[K]['type'] extends 'json'
                   ? object
                   : F[K]['type'] extends 'blob'
-                    ? Blob
+                    ? StoredObject
                     : F[K]['type'] extends 'date'
                       ? Date
                       : never;


### PR DESCRIPTION
This PR fixes a small bug with the `FieldsToTypes` type where the `blob` field was being mapped to a `Blob` type when we actually return JSON stored as a `StoredObject`.