### PR TITLE
Ensure working array instructions

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -218,12 +218,12 @@ export function getSyntaxProxy(config?: {
             value = { [QUERY_SYMBOLS.QUERY]: instructions.structure };
           } else {
             value = instructions;
-          }
 
-          if (isExpression(value)) {
-            value = wrapExpression(value as string);
-          } else if (typeof value === 'object') {
-            value = wrapExpressions(value);
+            if (isExpression(value)) {
+              value = wrapExpression(value as string);
+            } else if (typeof value === 'object') {
+              value = wrapExpressions(value);
+            }
           }
 
           // Restore the original value of `IN_BATCH`.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -64,6 +64,7 @@ const setPropertyViaPathSegments = (
       ) {
         current[key] = {};
       }
+
       current = current[key] as Record<string, object>;
     }
   }

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -199,6 +199,7 @@ describe('syntax proxy', () => {
     setProxy.accounts.to((f: Record<string, unknown>) => ({
       name: `${f.firstName} ${f.lastName}`,
       email: `${f.handle}@site.co`,
+      handle: 'newHandle',
     }));
 
     const finalQuery = {
@@ -211,6 +212,7 @@ describe('syntax proxy', () => {
             email: {
               [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD}handle || '@site.co'`,
             },
+            handle: 'newHandle',
           },
         },
       },

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -6,10 +6,10 @@ import { QUERY_SYMBOLS, type Query } from '@ronin/compiler';
 
 describe('syntax proxy', () => {
   test('using sub query', () => {
+    let query: Query | undefined;
+
     const getQueryHandler = { callback: () => undefined };
     const getQueryHandlerSpy = spyOn(getQueryHandler, 'callback');
-    const addQueryHandler = { callback: () => undefined };
-    const addQueryHandlerSpy = spyOn(addQueryHandler, 'callback');
 
     const getProxy = getSyntaxProxy({
       rootProperty: 'get',
@@ -17,17 +17,23 @@ describe('syntax proxy', () => {
     });
     const addProxy = getSyntaxProxy({
       rootProperty: 'add',
-      callback: addQueryHandlerSpy,
+      callback: (value) => {
+        query = value;
+      },
     });
 
-    addProxy.accounts.with(() => getProxy.oldAccounts());
+    addProxy.accounts.with(() => getProxy.oldAccounts.selecting(['handle']));
 
     const finalQuery = {
       add: {
         accounts: {
           with: {
             __RONIN_QUERY: {
-              get: { oldAccounts: {} },
+              get: {
+                oldAccounts: {
+                  selecting: ['handle'],
+                },
+              },
             },
           },
         },
@@ -35,7 +41,7 @@ describe('syntax proxy', () => {
     };
 
     expect(getQueryHandlerSpy).not.toHaveBeenCalled();
-    expect(addQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
+    expect(query).toMatchObject(finalQuery);
   });
 
   test('using field with expression', () => {


### PR DESCRIPTION
This change ensures that placing a single instruction at the end of a query with an array as the value works fine, without causing a broken query serialization output.

For example, the following query syntax...

```typescript
add.accounts.with(() => get.oldAccounts.selecting(['handle']));
```

...previously caused this serialized query representation:

```json
{
  "add": {
    "accounts": {
      "with": {
        "__RONIN_QUERY": {
          "get": {
            "oldAccounts": {
              "selecting": {
                "0": "handle"
              }
            }
          }
        }
      }
    }
  }
}
```

That's incorrect, because the `selecting` property should contain an array, not an object. Thanks to the current change, the query representation now looks like this:

```json
{
  "add": {
    "accounts": {
      "with": {
        "__RONIN_QUERY": {
          "get": {
            "oldAccounts": {
              "selecting": [
                "handle"
              ]
            }
          }
        }
      }
    }
  }
}
```