### PR TITLE
Fixed schema inferred type flattening

### DIFF
--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -106,7 +106,7 @@ type FieldsToTypes<F> = F extends Record<string, Primitives>
                     ? StoredObject
                     : F[K]['type'] extends 'date'
                       ? Date
-                      : never;
+                      : object;
     }
   : RoninFields;
 
@@ -152,7 +152,7 @@ type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
  */
 export const model = <Fields extends RecordWithoutForbiddenKeys<Primitives>>(
   model: Model<Fields>,
-): Expand<FieldsToTypes<Fields>> & Expand<RoninFields> => {
+): Expand<RoninFields & FieldsToTypes<Fields>> => {
   const newModel = { ...model };
 
   if (newModel.fields) {
@@ -173,5 +173,5 @@ export const model = <Fields extends RecordWithoutForbiddenKeys<Primitives>>(
     ) as unknown as typeof newModel.presets;
   }
 
-  return newModel as unknown as Expand<FieldsToTypes<Fields>> & Expand<RoninFields>;
+  return newModel as unknown as Expand<RoninFields & FieldsToTypes<Fields>>;
 };

--- a/tests/schema/model.test.ts
+++ b/tests/schema/model.test.ts
@@ -607,7 +607,6 @@ describe('models', () => {
     expect(Account).toEqual({
       // @ts-expect-error: The Account object has 'slug'.
       slug: 'account',
-      // @ts-expect-error: The Account object has 'presets'.
       presets: [
         {
           slug: 'onlyName',


### PR DESCRIPTION
This PR updates the `FieldsToTypes` type to change the default or failover type from `never` to `object`. This fixes an issue where the types inferred from a schema model were not getting flattened into a single object.

## Before
![CleanShot 2025-02-03 at 4  45 47@2x](https://github.com/user-attachments/assets/c5e6e129-cf52-470d-9431-b79d05ab68e3)

## After
![CleanShot 2025-02-03 at 4  46 06@2x](https://github.com/user-attachments/assets/571c73a7-54a2-4955-9065-bacbcd4ac913)
