### PR TITLE
Ensure inferred fields are marked as `null`

### DIFF
--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -100,25 +100,22 @@ export interface Model<Fields = RecordWithoutForbiddenKeys<Primitives>>
 }
 
 // This type maps the fields of a model to their types.
+type FieldToTypeMap = {
+  blob: StoredObject;
+  boolean: boolean;
+  date: Date;
+  json: object;
+  link: string;
+  number: number;
+  string: string;
+};
 type FieldsToTypes<F> = F extends Record<string, Primitives>
   ? {
       [K in keyof F]: F[K] extends Record<string, Primitives>
         ? FieldsToTypes<F[K]>
-        : F[K]['type'] extends 'string'
-          ? string
-          : F[K]['type'] extends 'number'
-            ? number
-            : F[K]['type'] extends 'boolean'
-              ? boolean
-              : F[K]['type'] extends 'link'
-                ? string
-                : F[K]['type'] extends 'json'
-                  ? object
-                  : F[K]['type'] extends 'blob'
-                    ? StoredObject
-                    : F[K]['type'] extends 'date'
-                      ? Date
-                      : object;
+        : F[K]['type'] extends keyof FieldToTypeMap
+          ? FieldToTypeMap[F[K]['type']]
+          : object;
     }
   : RoninFields;
 

--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -114,7 +114,9 @@ type FieldsToTypes<F> = F extends Record<string, Primitives>
       [K in keyof F]: F[K] extends Record<string, Primitives>
         ? FieldsToTypes<F[K]>
         : F[K]['type'] extends keyof FieldToTypeMap
-          ? FieldToTypeMap[F[K]['type']]
+          ? F[K]['required'] extends true
+            ? FieldToTypeMap[F[K]['type']]
+            : FieldToTypeMap[F[K]['type']] | null
           : object;
     }
   : RoninFields;

--- a/src/schema/primitives.ts
+++ b/src/schema/primitives.ts
@@ -24,8 +24,12 @@ export type Chain<Attrs, Used extends keyof Attrs = never> = {
     ...args: Array<AttributeSignature<TypeToTSType<Attrs['type']>, K>>
   ) => Chain<Attrs, Used | K>;
   // 2) If `type` is defined in `Attrs`, add it as a read-only property
-  // biome-ignore lint/complexity/noBannedTypes: This is a valid use case.
-} & ('type' extends keyof Attrs ? { readonly type: Attrs['type'] } : {});
+} & ('type' extends keyof Attrs
+  ? {
+      readonly required: boolean;
+      readonly type: Attrs['type'];
+    }
+  : object);
 
 type TypeToTSType<Type> = Type extends 'string'
   ? string


### PR DESCRIPTION
This PR applies both some minor refactoring changes, along with updating the necessary types in order to fix the inferred types of fields to mark them as `null` if they are not required.