### PR TITLE
Fixed model field expression default value type

### DIFF
--- a/src/schema/primitives.ts
+++ b/src/schema/primitives.ts
@@ -66,7 +66,7 @@ export type ModelFieldExpressions<Type> = {
     value: Type;
     kind: 'VIRTUAL' | 'STORED';
   };
-  defaultValue?: () => Type | Type;
+  defaultValue?: (() => Type) | Type;
 };
 
 export type SyntaxField<Type extends ModelField['type']> = SyntaxItem<FieldOutput<Type>>;


### PR DESCRIPTION
This PR fixes a small regression included as part of #32 where the `defaultValue` property was not correctly isolating the callback type. So it was assuming the property would only ever allow a callback function rather than a literal.