### PR TITLE
Support multi-line SQL statements

### DIFF
--- a/src/queries/statements.ts
+++ b/src/queries/statements.ts
@@ -30,7 +30,9 @@ export const getSyntaxProxySQL = (options: {
     });
 
     const statement: Statement = {
-      statement: text,
+      // Collapse whitespace and newlines into single spaces, then trim leading or
+      // trailing spaces.
+      statement: text.replace(/\s+/g, ' ').trim(),
       params,
     };
 

--- a/tests/queries/statements.test.ts
+++ b/tests/queries/statements.test.ts
@@ -43,3 +43,27 @@ test('using raw SQL in batch', async () => {
 
   expect(statementHandlerSpy).not.toHaveBeenCalled();
 });
+
+test('using raw SQL with multiple lines', async () => {
+  let statement: Statement | undefined;
+
+  const sqlProxy = getSyntaxProxySQL({
+    callback: (value) => {
+      statement = value;
+    },
+  });
+
+  const accountHandle = 'elaine';
+
+  sqlProxy`
+    UPDATE accounts
+    SET "points" = 11
+    WHERE "handle" = ${accountHandle}
+    RETURNING *
+  `;
+
+  expect(statement).toMatchObject({
+    statement: 'UPDATE accounts SET "points" = 11 WHERE "handle" = $1 RETURNING *',
+    params: ['elaine'],
+  });
+});


### PR DESCRIPTION
This change ensures that SQL statements spanning multiple lines are parsed just fine.