### PR TITLE
Added TSDoc example snippets to all field primitives

### DIFF
--- a/src/schema/primitives.ts
+++ b/src/schema/primitives.ts
@@ -93,6 +93,20 @@ const primitive = <T extends ModelField['type']>(type: T) => {
  * Creates a string field definition returning an object that includes the field type
  * ("string") and attributes.
  *
+ * @example
+ * ```ts
+ * import { model, string } from '@ronin/syntax/schema';
+ *
+ * const User = model({
+ *  slug: 'user',
+ *
+ *  fields: {
+ *    name: string(),
+ *    email: string({ required: true, unique: true })
+ *  },
+ * });
+ * ```
+ *
  * @param attributes - Optional field attributes.
  *
  * @returns A field of type "string" with the specified attributes.
@@ -102,6 +116,20 @@ export const string = primitive('string');
 /**
  * Creates a number field definition returning an object that includes the field type
  * ("number") and attributes.
+ *
+ * @example
+ * ```ts
+ * import { model, number } from '@ronin/syntax/schema';
+ *
+ * const User = model({
+ *  slug: 'user',
+ *
+ *  fields: {
+ *    points: number(),
+ *    numReferrals: number({ defaultValue: 0 })
+ *  },
+ * });
+ * ```
  *
  * @param attributes - Optional field attributes.
  *
@@ -113,6 +141,20 @@ export const number = primitive('number');
  * Creates a link field definition returning an object that includes the field type
  * ("link") and attributes.
  *
+ * @example
+ * ```ts
+ * import { model, link } from '@ronin/syntax/schema';
+ *
+ * const User = model({
+ *  slug: 'user',
+ *
+ *  fields: {
+ *    account: link({ target: 'account' }),
+ *    posts: link({ target: 'post', kind: 'many', required: true })
+ *  },
+ * });
+ * ```
+ *
  * @param attributes - Optional field attributes.
  *
  * @returns A field of type "link" with the specified attributes.
@@ -122,6 +164,19 @@ export const link = primitive('link');
 /**
  * Creates a JSON field definition returning an object that includes the field type
  * ("json") and attributes.
+ *
+ * @example
+ * ```ts
+ * import { model, json } from '@ronin/syntax/schema';
+ *
+ * const User = model({
+ *  slug: 'user',
+ *
+ *  fields: {
+ *    settings: json()
+ *  },
+ * });
+ * ```
  *
  * @param attributes - Optional field attributes.
  *
@@ -133,6 +188,20 @@ export const json = primitive('json');
  * Creates a date field definition returning an object that includes the field type
  * ("date") and attributes.
  *
+ * @example
+ * ```ts
+ * import { model, date } from '@ronin/syntax/schema';
+ *
+ * const User = model({
+ *  slug: 'user',
+ *
+ *  fields: {
+ *    lastActiveAt: date(),
+ *    deactivatedAt: date({ defaultValue: null })
+ *  },
+ * });
+ * ```
+ *
  * @param attributes - Optional field attributes.
  *
  * @returns A field of type "date" with the specified attributes.
@@ -143,6 +212,20 @@ export const date = primitive('date');
  * Creates a boolean field definition returning an object that includes the field type
  * ("boolean") and attributes.
  *
+ * @example
+ * ```ts
+ * import { model, boolean } from '@ronin/syntax/schema';
+ *
+ * const User = model({
+ *  slug: 'user',
+ *
+ *  fields: {
+ *    earlyAccess: boolean(),
+ *    isVerified: boolean({ defaultValue: false, required: true })
+ *  },
+ * });
+ * ```
+ *
  * @param attributes - Optional field attributes.
  *
  * @returns A field of type "boolean" with the specified attributes.
@@ -152,6 +235,20 @@ export const boolean = primitive('boolean');
 /**
  * Creates a blob field definition returning an object that includes the field type
  * ("blob") and attributes.
+ *
+ * @example
+ * ```ts
+ * import { model, blob } from '@ronin/syntax/schema';
+ *
+ * const User = model({
+ *  slug: 'user',
+ *
+ *  fields: {
+ *    avatar: blob(),
+ *    contents: blob({ required: true })
+ *  },
+ * });
+ * ```
  *
  * @param attributes - Optional field attributes.
  *


### PR DESCRIPTION
This PR adds some TSDoc example code snippets to all field primitives to give the user a easier quick glance on how possibly to use such fields.