### PR TITLE
Refactored `indexes` & `triggers` object structures

### DIFF
--- a/examples/models.ts
+++ b/examples/models.ts
@@ -14,22 +14,22 @@ export const Account = model({
     birthday: date(),
   },
 
-  indexes: [
-    {
+  indexes: {
+    name: {
       fields: [{ slug: 'name', order: 'ASC', collation: 'BINARY' }],
       unique: true,
     },
-  ],
+  },
 
-  triggers: [
-    {
+  triggers: {
+    afterInsert: {
       when: 'AFTER',
       action: 'INSERT',
       fields: [{ slug: 'name' }],
       // @ts-expect-error: The queries need to be adjusted in the TS client.
       effects: () => [add.member.with({ name: 'admin', email: 'admin@ronin.io' })],
     },
-  ],
+  },
 });
 
 export const Profile = model({

--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -82,12 +82,12 @@ export interface Model<Fields = RecordWithoutForbiddenKeys<Primitives>>
   /**
    * Database indexes to optimize query performance.
    */
-  indexes?: Array<ModelIndex<Array<ModelField & { slug: keyof Fields }>>>;
+  indexes?: Record<string, ModelIndex<Array<ModelField & { slug: keyof Fields }>>>;
 
   /**
    * Queries that run automatically in response to other queries.
    */
-  triggers?: Array<ModelTrigger<Array<ModelField & { slug: keyof Fields }>>>;
+  triggers?: Record<string, ModelTrigger<Array<ModelField & { slug: keyof Fields }>>>;
 
   /**
    * Predefined query instructions that can be reused across multiple different queries.

--- a/tests/schema/model.test.ts
+++ b/tests/schema/model.test.ts
@@ -454,11 +454,11 @@ describe('models', () => {
       fields: {
         name: string({ required: true }),
       },
-      indexes: [
-        {
+      indexes: {
+        name: {
           fields: [{ slug: 'name', order: 'ASC', collation: 'BINARY' }],
         },
-      ],
+      },
     });
     expect(Account).toBeTypeOf('object');
     // @ts-expect-error: The Account object has 'fields'.
@@ -476,11 +476,11 @@ describe('models', () => {
           required: true,
         },
       ],
-      indexes: [
-        {
+      indexes: {
+        name: {
           fields: [{ slug: 'name', order: 'ASC', collation: 'BINARY' }],
         },
-      ],
+      },
     });
   });
 
@@ -493,14 +493,14 @@ describe('models', () => {
         fields: {
           name: string({ required: true }),
         },
-        indexes: [
-          {
+        indexes: {
+          name: {
             fields: [
               // @ts-expect-error This is intended.
               { slug: 'thisFieldDoesNotExist', order: 'ASC', collation: 'BINARY' },
             ],
           },
-        ],
+        },
       });
     } catch (err) {
       const error = err as Error;
@@ -520,11 +520,11 @@ describe('models', () => {
         fields: {
           name: string({ required: true }),
         },
-        indexes: [
-          {
+        indexes: {
+          name: {
             fields: [],
           },
-        ],
+        },
       });
     } catch (err) {
       const error = err as Error;
@@ -543,15 +543,15 @@ describe('models', () => {
       fields: {
         name: string({ required: true }),
       },
-      triggers: [
-        {
+      triggers: {
+        afterInsert: {
           action: 'INSERT',
           when: 'AFTER',
           fields: [{ slug: 'name' }],
           // @ts-expect-error: The queries need to be adjusted in the TS client.
           effects: [add.account.with({ name: 'Lorena' })],
         },
-      ],
+      },
     }));
 
     expect(Account).toBeTypeOf('object');
@@ -570,8 +570,8 @@ describe('models', () => {
           required: true,
         },
       ],
-      triggers: [
-        {
+      triggers: {
+        afterInsert: {
           action: 'INSERT',
           when: 'AFTER',
           effects: [
@@ -589,7 +589,7 @@ describe('models', () => {
           ],
           fields: [{ slug: 'name' }],
         },
-      ],
+      },
     });
   });
 


### PR DESCRIPTION
This PR makes a small change to both the `indexes` & `triggers` properties of the `model` function options such that instead of an array of properties we instead now use a key/value object.

This has been implemented in order to make these 2 properties more consistent with the `fields` property.