### PR TITLE
Prevent crash if batch contains empty values

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,6 +1,6 @@
 import type { DeepCallable, ResultRecord } from '@/src/queries/types';
 import type { Model } from '@/src/schema';
-import { mutateStructure, setProperty } from '@/src/utils';
+import { isPlainObject, mutateStructure, setProperty } from '@/src/utils';
 import { type ModelField, QUERY_SYMBOLS, type Query } from '@ronin/compiler';
 
 /**
@@ -219,6 +219,10 @@ export const getBatchProxy = (
   // objects, thereby making development more difficult. To avoid this, we are creating a
   // plain object containing the same properties as the `Proxy` instances.
   return queries.map((details) => {
+    // If a placeholder value such as `null` is located inside the batch, we need to
+    // return it as-is instead of processing it as a query.
+    if (!isPlainObject(details)) return { structure: details };
+
     const item: SyntaxItem = {
       structure: (details as unknown as Record<typeof QUERY_SYMBOLS.QUERY, Query>)[
         QUERY_SYMBOLS.QUERY

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -126,7 +126,7 @@ export const getProperty = (obj: object, path: string): unknown => {
  *
  * @returns A boolean indicating whether the object is plain, or not.
  */
-const isPlainObject = (value: unknown): boolean => {
+export const isPlainObject = (value: unknown): boolean => {
   return Object.prototype.toString.call(value) === '[object Object]';
 };
 

--- a/tests/queries/index.test.ts
+++ b/tests/queries/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, spyOn, test } from 'bun:test';
 
 import { op } from '@/src/helpers/expressions';
-import { getBatchProxy, getSyntaxProxy } from '@/src/queries';
+import { type SyntaxItem, getBatchProxy, getSyntaxProxy } from '@/src/queries';
 import { concat, string } from '@/src/schema';
 import {
   type AddQuery,
@@ -435,6 +435,36 @@ describe('syntax proxy', () => {
     expect(queries.length === 1 ? { result: true } : null).toMatchObject({
       result: true,
     });
+  });
+
+  test('using queries with placeholder in batch', () => {
+    const getProxy = getSyntaxProxy<GetQuery>({ root: `${QUERY_SYMBOLS.QUERY}.get` });
+
+    const queries = getBatchProxy(() => [
+      getProxy.account(),
+      null as unknown as SyntaxItem<Query>,
+      getProxy.team(),
+    ]);
+
+    expect(queries).toMatchObject([
+      {
+        structure: {
+          get: {
+            account: {},
+          },
+        },
+      },
+      {
+        structure: null,
+      },
+      {
+        structure: {
+          get: {
+            team: {},
+          },
+        },
+      },
+    ]);
   });
 
   test('using options for query in batch', () => {


### PR DESCRIPTION
It is perfectly normal to place a value such as `null` inside a batch, because that makes it easy to construct batches with multiple queries, where each one is constructed using a ternary. Without placeholders like those, all the values after it would of course shift one array index upward, which is not an option.

The latest syntax no longer supports these kinds of values, so I'm adding back support for them.