### PR TITLE
Fix model `presets` object types

### DIFF
--- a/examples/models.ts
+++ b/examples/models.ts
@@ -65,12 +65,14 @@ export const Member = model({
 
   presets: {
     specificSpace: {
-      with: {
-        space: {
-          being: 'spa_m9h8oha94helaji',
+      instructions: {
+        with: {
+          space: {
+            being: 'spa_m9h8oha94helaji',
+          },
         },
+        selecting: ['name'],
       },
-      selecting: ['name'],
     },
   },
 });

--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -12,13 +12,12 @@ import type {
   string,
 } from '@/src/schema';
 import type {
-  GetInstructions,
   ModelField,
   ModelIndex,
+  ModelPreset,
   ModelTrigger,
   Model as RawModel,
   StoredObject,
-  WithInstruction,
 } from '@ronin/compiler';
 
 // This is used to ensure that any object adhering to this interface has both fields.
@@ -93,8 +92,8 @@ export interface Model<Fields = RecordWithoutForbiddenKeys<Primitives>>
    * Predefined query instructions that can be reused across multiple different queries.
    */
   presets?:
-    | Record<string, GetInstructions | WithInstruction>
-    | ((fields: keyof Fields) => Record<string, GetInstructions | WithInstruction>);
+    | Record<string, Omit<ModelPreset, 'slug'>>
+    | ((fields: keyof Fields) => Record<string, Omit<ModelPreset, 'slug'>>);
 }
 
 // This type maps the fields of a model to their types.

--- a/tests/schema/model.test.ts
+++ b/tests/schema/model.test.ts
@@ -579,12 +579,14 @@ describe('models', () => {
       slug: 'account',
       presets: {
         onlyName: {
-          with: {
-            space: {
-              being: 'spa_m9h8oha94helaji',
+          instructions: {
+            with: {
+              space: {
+                being: 'spa_m9h8oha94helaji',
+              },
             },
+            selecting: ['name'],
           },
-          selecting: ['name'],
         },
       },
     });
@@ -594,12 +596,14 @@ describe('models', () => {
       slug: 'account',
       presets: {
         onlyName: {
-          with: {
-            space: {
-              being: 'spa_m9h8oha94helaji',
+          instructions: {
+            with: {
+              space: {
+                being: 'spa_m9h8oha94helaji',
+              },
             },
+            selecting: ['name'],
           },
-          selecting: ['name'],
         },
       },
     });
@@ -615,9 +619,11 @@ describe('models', () => {
       },
       presets: (f) => ({
         account: {
-          including: {
-            // @ts-expect-error This will be improved shortly.
-            account: getProxy.account.with.id(f.account),
+          instructions: {
+            including: {
+              // @ts-expect-error This will be improved shortly.
+              account: getProxy.account.with.id(f.account),
+            },
           },
         },
       }),
@@ -633,14 +639,16 @@ describe('models', () => {
       },
       presets: {
         account: {
-          including: {
-            account: {
-              [QUERY_SYMBOLS.QUERY]: {
-                get: {
-                  account: {
-                    with: {
-                      id: {
-                        [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD}account`,
+          instructions: {
+            including: {
+              account: {
+                [QUERY_SYMBOLS.QUERY]: {
+                  get: {
+                    account: {
+                      with: {
+                        id: {
+                          [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD}account`,
+                        },
                       },
                     },
                   },


### PR DESCRIPTION
This PR fixes a small regression introduced as part of #52 where the types for a model `presets` property were incorrectly updated.