### PR TITLE
Added support for `replace()`

### DIFF
--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -122,3 +122,18 @@ export const concat = (
 
   return expression(`concat(${formattedValues.join(', ')})`) as unknown as string;
 };
+
+/**
+ * Replaces all occurrences of a substring within a string with a replacement value.
+ *
+ * @param input - The string to perform replacements on.
+ * @param search - The substring to search for.
+ * @param replacement - The string to replace matches with.
+ *
+ * @returns SQL expression that evaluates to the modified string.
+ */
+export const replace = (input: string, search: string, replacement: string): string => {
+  return expression(
+    `replace('${input}', '${search}', '${replacement}')`,
+  ) as unknown as string;
+};

--- a/tests/helpers/expressions.test.ts
+++ b/tests/helpers/expressions.test.ts
@@ -7,6 +7,7 @@ import {
   json_replace,
   json_set,
   random,
+  replace,
   sql,
   strftime,
 } from '@/src/helpers/functions';
@@ -465,6 +466,29 @@ describe('expressions', () => {
     // @ts-expect-error This exists
     expect(Test.fields.test.defaultValue).toEqual({
       __RONIN_EXPRESSION: "(('Hello' || 'World') || ('Hello' || 'World'))",
+    });
+  });
+
+  test('replace expression', () => {
+    const Test = model({
+      slug: 'test',
+      fields: {
+        simpleReplace: string().defaultValue(() =>
+          replace('hello world', 'world', 'there'),
+        ),
+        multiReplace: string().defaultValue(() =>
+          replace('hello hello hello', 'hello', 'hi'),
+        ),
+      },
+    });
+    expect(Test).toBeTypeOf('object');
+    // @ts-expect-error This exists
+    expect(Test.fields.simpleReplace.defaultValue).toEqual({
+      __RONIN_EXPRESSION: "replace('hello world', 'world', 'there')",
+    });
+    // @ts-expect-error This exists
+    expect(Test.fields.multiReplace.defaultValue).toEqual({
+      __RONIN_EXPRESSION: "replace('hello hello hello', 'hello', 'hi')",
     });
   });
 });


### PR DESCRIPTION
This PR adds the core sql function [`replace()`](https://www.sqlite.org/lang_corefunc.html#replace).