### PR TITLE
Ensure correct behavior for model definition

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -52,10 +52,13 @@ export const getSyntaxProxy = <Structure, ReturnValue = ResultRecord>(config?: {
   replacer?: (value: unknown) => unknown | undefined;
   propertyValue?: unknown;
   modelType?: boolean;
+  chaining?: boolean;
 }): DeepCallable<Structure, ReturnValue> => {
   // The default value of a property within the composed structure.
   const propertyValue =
     typeof config?.propertyValue === 'undefined' ? {} : config.propertyValue;
+
+  const shouldAllowChaining = config?.chaining ?? true;
 
   const createProxy = (
     path: Array<string> = [],
@@ -115,7 +118,7 @@ export const getSyntaxProxy = <Structure, ReturnValue = ResultRecord>(config?: {
           // holds an `undefined` value.
           if (options) details.options = options;
 
-          return createProxy(newPath, details, true);
+          return shouldAllowChaining ? createProxy(newPath, details, true) : details;
         }
 
         return config.callback(structure, options);

--- a/src/schema/model.ts
+++ b/src/schema/model.ts
@@ -161,7 +161,7 @@ type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 export const model = <Fields extends RecordWithoutForbiddenKeys<Primitives>>(
   model: Model<Fields> | (() => Model<Fields>),
 ): Expand<RoninFields & FieldsToTypes<Fields>> => {
-  return getSyntaxProxy({ modelType: true })(model) as unknown as Expand<
+  return getSyntaxProxy({ modelType: true, chaining: false })(model) as unknown as Expand<
     RoninFields & FieldsToTypes<Fields>
   >;
 };


### PR DESCRIPTION
This change ensures that the `model()` function always returns an object and never a JS proxy.

As a result, the migration commands in the CLI will work as expected again.