### PR TITLE
Allow for providing model-specific instructions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "@ronin/syntax",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@ronin/compiler": "0.17.9",
+        "@ronin/compiler": "0.17.11",
         "@types/bun": "1.2.3",
         "expect-type": "1.1.0",
         "tsup": "8.3.6",
@@ -134,7 +134,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.34.8", "", { "os": "win32", "cpu": "x64" }, "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.9", "", {}, "sha512-g19E0fEHK/QelBZAlGG54cgP5apPLpMQyk2mgYzQBQyUhBhb0Ijf+tkgbquVRnRddC39mO8+w2ISt2ibeK7RSw=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.11", "", {}, "sha512-6lPjWe8tHShsrAhVR1KnEKBgCf2YjC0WHjMu7TSsg0DmveSmUcFJbv9hdie2ERjcQFnq31xRzRQUESsFIEYAow=="],
 
     "@types/bun": ["@types/bun@1.2.3", "", { "dependencies": { "bun-types": "1.2.3" } }, "sha512-054h79ipETRfjtsCW9qJK8Ipof67Pw9bodFWmkfkaUaRiIQ1dIV2VTlheshlBx3mpKr0KeK8VqnMMCtgN9rQtw=="],
 
@@ -184,7 +184,7 @@
 
     "fdir": ["fdir@6.4.3", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw=="],
 
-    "foreground-child": ["foreground-child@3.3.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "signal-exit": "^4.0.1" } }, "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg=="],
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@ronin/compiler": "0.17.9",
+    "@ronin/compiler": "0.17.11",
     "@types/bun": "1.2.3",
     "expect-type": "1.1.0",
     "tsup": "8.3.6",


### PR DESCRIPTION
This change allows for providing instructions that apply only to a specific model, when using queries that affect all models.

Originally, the change was landed in https://github.com/ronin-co/compiler/pull/155.