### PR TITLE
Identify system-generated model entities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "@ronin/syntax",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@ronin/compiler": "0.17.11",
+        "@ronin/compiler": "0.17.13",
         "@types/bun": "1.2.3",
         "expect-type": "1.1.0",
         "tsup": "8.3.6",
@@ -134,7 +134,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.34.8", "", { "os": "win32", "cpu": "x64" }, "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.11", "", {}, "sha512-6lPjWe8tHShsrAhVR1KnEKBgCf2YjC0WHjMu7TSsg0DmveSmUcFJbv9hdie2ERjcQFnq31xRzRQUESsFIEYAow=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.13", "", {}, "sha512-mK5wOf2mNeqQmAy6D0lDQ9oip2dXfXJuI9ba4yjoVNb0zrS8OWPDrX98ATjfNE5sDpZbdmCwmRWgSSGXZBAMig=="],
 
     "@types/bun": ["@types/bun@1.2.3", "", { "dependencies": { "bun-types": "1.2.3" } }, "sha512-054h79ipETRfjtsCW9qJK8Ipof67Pw9bodFWmkfkaUaRiIQ1dIV2VTlheshlBx3mpKr0KeK8VqnMMCtgN9rQtw=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@ronin/compiler": "0.17.11",
+    "@ronin/compiler": "0.17.13",
     "@types/bun": "1.2.3",
     "expect-type": "1.1.0",
     "tsup": "8.3.6",

--- a/src/schema/primitives.ts
+++ b/src/schema/primitives.ts
@@ -51,7 +51,7 @@ type FieldInput<Type extends ModelField['type']> = Partial<
 
 export type FieldOutput<Type extends ModelField['type']> = Omit<
   Extract<ModelField & ModelFieldExpressions<TypeToTSType<Type>>, { type: Type }>,
-  'slug'
+  'slug' | 'system'
 >;
 
 export type ModelFieldExpressions<Type> = {


### PR DESCRIPTION
This change ensures that model entities (fields, presets, etc.) that were automatically generated by RONIN are clearly marked as such, to prevent them from getting mixed up with the ones that were provided explicitly.

Originally, the change was landed in https://github.com/ronin-co/compiler/pull/157.