### PR TITLE
Restrict certain model slugs

### DIFF
--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -86,7 +86,11 @@ type InstructionMethods<Query, Result> = {
  * `DeepCallable<Query, FinalResult>`.
  */
 type ObjectCall<Query, DefaultResult, Arg> = (<FinalResult = DefaultResult>(
-  arg?: ((f: Record<string, unknown>) => Arg | any) | Arg | Array<Arg>,
+  arg?:
+    | ((f: Record<string, unknown>) => Arg | any)
+    | Arg
+    | Array<Arg>
+    | Record<string, Arg>,
   options?: Record<string, unknown>,
 ) => Promise<FinalResult> &
   InstructionMethods<Query, FinalResult> &

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -39,7 +39,7 @@ export type DeepCallable<Query, Result = ResultRecord> = [NonNullable<Query>] ex
      * Calls the object with an optional partial argument, returning a promise that
      * resolves to `Result` and also remains a DeepCallable for further nested calls.
      */
-    ObjectCall<Query, Result, Partial<NonNullable<Query>>> & {
+    ObjectCall<Query, Result, NonNullable<Query>> & {
       /**
        * For each key in Query, exclude null/undefined so we can call it without TS
        * complaining about it possibly being undefined.

--- a/tests/schema/model.test.ts
+++ b/tests/schema/model.test.ts
@@ -823,4 +823,18 @@ describe('models', () => {
       };
     }>();
   });
+
+  test('create model with an invalid slug', () => {
+    model({
+      // @ts-expect-error We're intentionally passing an invalid slug.
+      slug: 'model',
+    });
+  });
+
+  test('create model with an empty slug', () => {
+    model({
+      // @ts-expect-error We're intentionally passing an invalid slug.
+      slug: '',
+    });
+  });
 });


### PR DESCRIPTION
This PR updates the types for the schema models to not allow certain slugs. In this case, just `''` & `'model'`.

Additionally some other minor type improvements & fixes have been made.