### PR TITLE
Improve `ResultRecord` type readability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "@ronin/syntax",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@ronin/compiler": "0.17.16",
+        "@ronin/compiler": "0.17.19",
         "@types/bun": "1.2.4",
         "expect-type": "1.2.0",
         "tsup": "8.4.0",
@@ -134,7 +134,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.34.9", "", { "os": "win32", "cpu": "x64" }, "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.16", "", {}, "sha512-pIo6KoGVFjOSwJTNgAtRpnKdhaAUVzqGpsD5Qn50LagEkYrpGDOKzD5+A0nfRfYPyOliOQD3GSF7YyJAqnG3gg=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.19", "", {}, "sha512-5rHCRZAXyI35AGQ8ODMnKQJa8HjZQ6M/d3fULwGWVK0RQC/G6gXlUROTAxJa318yHl+xsy2R3x0mKpVXgFUrGQ=="],
 
     "@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@ronin/compiler": "0.17.16",
+    "@ronin/compiler": "0.17.19",
     "@types/bun": "1.2.4",
     "expect-type": "1.2.0",
     "tsup": "8.4.0",

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -1,30 +1,10 @@
-import type { CombinedInstructions, WithInstruction } from '@ronin/compiler';
+import type {
+  CombinedInstructions,
+  ResultRecordBase,
+  WithInstruction,
+} from '@ronin/compiler';
 
-export type ResultRecord = {
-  /**
-   * A unique identifier of the record.
-   */
-  id: string;
-
-  ronin: {
-    /**
-     * A timestamp of when the record was created.
-     */
-    createdAt: Date;
-    /**
-     * The ID of the user who created the record.
-     */
-    createdBy: string | null;
-    /**
-     * A timestamp of when the record was last updated or modified.
-     */
-    updatedAt: Date;
-    /**
-     * The ID of the user who last updated or modified the record.
-     */
-    updatedBy: string | null;
-  };
-};
+export type ResultRecord = ResultRecordBase<Date>;
 
 type WithInstructionKeys<T> = T extends WithInstruction
   ? keyof (T extends Array<infer U> ? U : T)

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -4,6 +4,14 @@ import type {
   WithInstruction,
 } from '@ronin/compiler';
 
+type FlattenObject<T> = {
+  [K in keyof T]: T[K] extends Date
+    ? T[K]
+    : T[K] extends object
+      ? FlattenObject<T[K]>
+      : T[K];
+} & {};
+
 export type ResultRecord = Omit<OriginalRecord, 'ronin'> & {
   ronin: Omit<OriginalRecord['ronin'], 'createdAt' | 'updatedAt'> & {
     createdAt: Date;

--- a/src/queries/types.ts
+++ b/src/queries/types.ts
@@ -1,21 +1,28 @@
-import type {
-  CombinedInstructions,
-  ResultRecord as OriginalRecord,
-  WithInstruction,
-} from '@ronin/compiler';
+import type { CombinedInstructions, WithInstruction } from '@ronin/compiler';
 
-type FlattenObject<T> = {
-  [K in keyof T]: T[K] extends Date
-    ? T[K]
-    : T[K] extends object
-      ? FlattenObject<T[K]>
-      : T[K];
-} & {};
+export type ResultRecord = {
+  /**
+   * A unique identifier of the record.
+   */
+  id: string;
 
-export type ResultRecord = Omit<OriginalRecord, 'ronin'> & {
-  ronin: Omit<OriginalRecord['ronin'], 'createdAt' | 'updatedAt'> & {
+  ronin: {
+    /**
+     * A timestamp of when the record was created.
+     */
     createdAt: Date;
+    /**
+     * The ID of the user who created the record.
+     */
+    createdBy: string | null;
+    /**
+     * A timestamp of when the record was last updated or modified.
+     */
     updatedAt: Date;
+    /**
+     * The ID of the user who last updated or modified the record.
+     */
+    updatedBy: string | null;
   };
 };
 


### PR DESCRIPTION
This change de-couples the `ResultRecord` type from the `@ronin/compiler` package in order to hard code the type with improve readability and documentation.