### PR TITLE
Ensure reliable batch context

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  var IN_RONIN_BATCH: boolean;
+}
+
+export {};


### PR DESCRIPTION
This change ensures that queries always correctly detect whether they are running inside a batch, by ensuring that the context does not depend on a specific file being imported, but instead on a global variable.